### PR TITLE
Add Dockerfile and usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# -------- Build stage --------
+FROM node:18 AS builder
+WORKDIR /app
+
+# Install dependencies and build all workspaces
+COPY package*.json bun.lock turbo.json ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install
+RUN npm run build
+
+# -------- Runtime stage --------
+FROM node:18-slim
+WORKDIR /app
+
+# Install server runtime dependencies only
+COPY apps/server/package*.json ./server/
+RUN npm install --omit=dev --prefix ./server
+
+# Copy compiled server and built client
+COPY --from=builder /app/apps/server/dist ./server/dist
+COPY --from=builder /app/apps/client/dist ./client/dist
+
+# 'serve' will host the static client build
+RUN npm install -g serve
+
+COPY start.sh .
+
+EXPOSE 4000 3000
+CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+node server/dist/index.js &
+serve -s client/dist -l 3000 &
+wait -n


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile with build and runtime steps
- add start script for server and client
- document Docker usage and explain Dockerfile contents

## Testing
- `bun lint` *(fails: Cannot read config file)*

------
https://chatgpt.com/codex/tasks/task_e_688ab9d677b0832484e0521cc964f731